### PR TITLE
Fix webpack on aarch64 (and potentially others)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "extract-loader": "^5.1.0",
     "file-loader": "^6.2.0",
     "lodash": "^4.17.20",
-    "node-sass": "^7.0.1",
+    "sass": "^1.68.0",
     "optimize-css-assets-webpack-plugin": "^5.0.4",
     "qs": "^6.9.4",
     "raven-js": "^3.27.2",


### PR DESCRIPTION
Swapping out the deprecated `node-sass` with `sass` allows a aarach64 Android device to webpack successfully.

Otherwise, `node-sass` emits errors about `undefined-symbol` and webpack fails.