### PR TITLE
Fix [hr] in collapse title

### DIFF
--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -72,12 +72,15 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
             const icon = parser.createElement('i');
             icon.className = 'fas fa-chevron-down';
             icon.style.marginRight = '10px';
-            headerText.appendChild(icon);
 						// HACK: to allow [hr] in header part
-						param = Utils.replaceAll(param, "[hr]", "<hr>");
-  		      const headerText2 = parser.createElement("div");
-      		  headerText2.innerHTML = param;
-        		headerText.appendChild(headerText2);
+						if (param.startsWith('[hr]')) { headerText.appendChild(parser.createElement('hr')); param = param.slice(4) }
+						headerText.appendChild(icon);
+						const splitParam = param.split('[hr]')
+						for (let iii = 0; iii < splitParam.length; iii++) {
+							const element = splitParam[iii];
+							headerText.appendChild(document.createTextNode(element));
+							if (iii < splitParam.length-1) headerText.appendChild(parser.createElement('hr'))
+						}
             outer.appendChild(headerText);
             const body = parser.createElement('div');
             body.className = 'bbcode-collapse-body';

--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -73,7 +73,11 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
             icon.className = 'fas fa-chevron-down';
             icon.style.marginRight = '10px';
             headerText.appendChild(icon);
-            headerText.appendChild(document.createTextNode(param));
+						// HACK: to allow [hr] in header part
+						param = Utils.replaceAll(param, "[hr]", "<hr>");
+  		      const headerText2 = parser.createElement("div");
+      		  headerText2.innerHTML = param;
+        		headerText.appendChild(headerText2);
             outer.appendChild(headerText);
             const body = parser.createElement('div');
             body.className = 'bbcode-collapse-body';

--- a/site/utils.ts
+++ b/site/utils.ts
@@ -82,3 +82,13 @@ export function init(s: Settings, c: SimpleCharacter[]): void {
     settings = s;
     characters = c;
 }
+
+function escapeRegExp(string: string):
+string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
+}
+
+export function replaceAll(str: string, find: string, replace: string):
+string {
+  return str.replace(new RegExp(escapeRegExp(find), "g"), replace);
+}


### PR DESCRIPTION
A lot of users add [hr] tags in their collapse title. While F-list records that it is a normal behaviour to not parse [hr] tags in collapse titles, a lot of people I interact with think don't want to use the app because of this "parsing issue".

A quick fix of mine has been to basically bypass in the parser when there is any [hr] tags in the parameter, and then replace the [hr] by <hr> to show them.