### PR TITLE
Somehow fixes check/uncheck behaviour in ad launcher

### DIFF
--- a/chat/ads/AdLauncher.vue
+++ b/chat/ads/AdLauncher.vue
@@ -142,7 +142,9 @@ export default class AdLauncherDialog extends CustomDialog {
     e.preventDefault();
     e.stopPropagation();
 
-    _.each(this.channels, (c) => c.value = newValue);
+    _.each(this.channels, (c) => {
+      c.value = newValue
+    });
   }
 
   submit(e: Event) {


### PR DESCRIPTION
I'm genuinely stumped why adding curly braces seems to have fixed this, since I don't think that the JS event being called is asynchronous and even then I think that the compiler treats these the same. Regardless, I initially only added them so I could print the channel's state and the new value in the console to pinpoint the cause of the bug, but in doing so managed to solve it already.

Broken behaviour:

https://github.com/hearmeneigh/fchat-rising/assets/82377182/c0a17e0e-fbc5-4fe1-8448-ec910ba701fa

Fixed (supposedly intended) behaviour:

https://github.com/hearmeneigh/fchat-rising/assets/82377182/8119a932-04f7-48f2-9d30-eac1319be75e


I haven't tested the fixed version on any platform but MacOS, but I do know that the bug also occurs in the Windows version.
The bug wasn't reported yet because I kept telling myself I'd fix it myself, but forgot to over the last X months. Whoops!