### PR TITLE
Fixes the nonbinary default kink not being taken into account w/ gender matching

### DIFF
--- a/learn/matcher.ts
+++ b/learn/matcher.ts
@@ -746,6 +746,8 @@ export class Matcher {
                     Orientation.BiFemalePreference,
                     Orientation.BiMalePreference
                 ].includes(yourOrientation)) {
+                    let nonBinaryPref:KinkPreference|null = Matcher.getKinkPreference(you, Kink.Nonbinary);
+                    if(nonBinaryPref != null) return Matcher.formatKinkScore(nonBinaryPref, 'non-binary genders');
                     return new Score(Scoring.MISMATCH, 'No <span>non-binary</span> genders');
                 }
             }


### PR DESCRIPTION
Closes #326.

Previously 'Nonbinary' default kink was ignored— provided your character's orientation isn't set to pansexual, unsure or left blank, when trying to match profiles with nonbinary genders if their specific gender option wasn't determined.

Now it also checks if you have a preference for nonbinary characters and uses that if it can't find one for the character's specific gender.