### PR TITLE
Added an endless ad posting method

### DIFF
--- a/chat/ConversationView.vue
+++ b/chat/ConversationView.vue
@@ -620,7 +620,7 @@
                     ((adManager.getNextPostDue()) && (!adManager.getFirstPost())) ? 'admgr.postingBegins' : 'admgr.nextPostDue',
                     diffMins,
                     diffSecs
-                ) + l('admgr.expiresIn', expDiffMins, expDiffSecs);
+                ) + (Number.isNaN(expDiffMins) || Number.isNaN(expDiffSecs) ? l('admgr.neverExpires') : l('admgr.expiresIn', expDiffMins, expDiffSecs));
 
                 this.adsRequireSetup = false;
             } else {

--- a/chat/ads/AdLauncher.vue
+++ b/chat/ads/AdLauncher.vue
@@ -89,7 +89,8 @@ export default class AdLauncherDialog extends CustomDialog {
     { value: 30, title: '30 minutes' },
     { value: 60, title: '1 hour' },
     { value: 120, title: '2 hours' },
-    { value: 180, title: '3 hours' }
+    { value: 180, title: '3 hours' },
+    { value: Number.MAX_SAFE_INTEGER, title: 'Endless' }
   ]
 
   load() {

--- a/chat/ads/ad-manager.ts
+++ b/chat/ads/ad-manager.ts
@@ -22,7 +22,7 @@ export interface RecoverableAd {
 
 
 export class AdManager {
-    static readonly POSTING_PERIOD = 3 * 60 * 60 * 1000;
+    static readonly POSTING_PERIOD = Number.MAX_SAFE_INTEGER;
     static readonly START_VARIANCE = 3 * 60 * 1000;
     static readonly POST_VARIANCE = 8 * 60 * 1000;
     static readonly POST_DELAY = 1.5 * 60 * 1000;

--- a/chat/localize.ts
+++ b/chat/localize.ts
@@ -20,6 +20,7 @@ const strings: {[key: string]: string | undefined} = {
     'admgr.postingBegins': 'Posting beings in {0}m {1}s',
     'admgr.nextPostDue': 'Next ad in {0}m {1}s',
     'admgr.expiresIn': ', auto-posting expires in {0}m {1}s',
+    'admgr.neverExpires': ', auto-posting never expires',
     'admgr.noAds': 'No ads have been set up -- auto-posting will be cancelled. Click "Ads > Edit Channel Ads..." to set up your ads.',
     'admgr.activeHeader': 'Auto-Posting Ads',
     'admgr.comingNext': 'Coming Next',


### PR DESCRIPTION
I find the limit of 3 hours very arbitrary. While I prefer to add a more freeform input, adding an option for ads to simply be endless (and thus to toggle them on or off essentially) was rather simple to accomplish.