### PR TITLE
Stops pinging frontpage when note checker is disabled

### DIFF
--- a/site/note-checker.ts
+++ b/site/note-checker.ts
@@ -1,6 +1,7 @@
 import { SiteSession, SiteSessionInterface } from './site-session';
 import log from 'electron-log'; //tslint:disable-line:match-default-export-name
 import { EventBus } from '../chat/preview/event-bus';
+import core from '../chat/core';
 
 /* tslint:disable:no-unsafe-any */
 
@@ -57,6 +58,8 @@ export class NoteChecker implements SiteSessionInterface {
 
   private async check(): Promise<NoteCheckerCount> {
     log.debug('notechecker.check');
+
+    if (!core.state.settings.risingShowUnreadOfflineCount) return this.latestCount;
 
     const res = await this.session.get('/', true);
     const messagesMatch = res.body.match(/NavigationMessages.*?([0-9]+?) Messages/);


### PR DESCRIPTION
So now you don't have people thinking you're actually around while you have Rising open and idle because it keeps fetching notes every X minutes.