### PR TITLE
Fixes purple text in black text bbcode tags not having the proper shadow in the default theme

### DIFF
--- a/scss/themes/variables/_default_derived.scss
+++ b/scss/themes/variables/_default_derived.scss
@@ -2,8 +2,9 @@
   @include text-outline(#306);
 }
 
-.blackText {
+.blackText, .blackText .purpleText{
   @include text-outline($gray-600);
 }
+
 
 $blue-color: #06f;


### PR DESCRIPTION
<img width="263" alt="image" src="https://github.com/user-attachments/assets/e5141e9b-defc-4c24-9b82-75fd46e7a59d">


It's not super legible, but honestly neither are the other colours when you do this trick. At least it's consistent with all the other themes (and colours) now.

Fixes #425 